### PR TITLE
Added UI to upload a profile photo

### DIFF
--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,15 @@
+interface ProfilePhotoProps {
+  photoURL: string;
+}
+
+const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ photoURL }) => {
+  return (
+    <img
+      alt="Profile Image"
+      style={{ textAlign: 'center', width: '60%', borderRadius: '50%', overflow: 'hidden' }}
+      src={photoURL}
+    />
+  );
+};
+
+export default ProfilePhoto;

--- a/client/src/components/SettingsHeader/SettingsHeader.tsx
+++ b/client/src/components/SettingsHeader/SettingsHeader.tsx
@@ -13,7 +13,7 @@ const SettingHeader: React.FC<SettingHeaderProps> = ({ header }) => {
         sx={{
           fontWeight: 700,
           textAlign: 'center',
-          marginBottom: 8,
+          marginBottom: '8px',
         }}
       >
         {header}

--- a/client/src/pages/Settings/EditProfilePhoto/EditProfilePhoto.tsx
+++ b/client/src/pages/Settings/EditProfilePhoto/EditProfilePhoto.tsx
@@ -34,7 +34,7 @@ const EditProfilePhoto: React.FC<EditProfilePhotoProps> = ({ header, currentUser
         </Typography>
       </Grid>
       <Grid item xs={12} sx={{ textAlign: 'center', margin: '20px' }}>
-        <Button component="label" size="large" variant="outlined" color="secondary" onChange={onChange}>
+        <Button component="label" size="large" variant="outlined" color="primary" onChange={onChange}>
           Upload A Photo From Your Device
           <input type="file" hidden />
         </Button>

--- a/client/src/pages/Settings/EditProfilePhoto/EditProfilePhoto.tsx
+++ b/client/src/pages/Settings/EditProfilePhoto/EditProfilePhoto.tsx
@@ -1,0 +1,52 @@
+import SettingHeader from '../../../components/SettingsHeader/SettingsHeader';
+import ProfilePhoto from '../../../components/ProfilePhoto/ProfilePhoto';
+import { Button } from '@mui/material';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import { Grid, Typography } from '@mui/material/';
+import { User } from '../../../interface/User';
+
+interface EditProfilePhotoProps {
+  header: string;
+  currentUser?: User;
+  currentProfile?: { photoURL: string | undefined };
+}
+
+const EditProfilePhoto: React.FC<EditProfilePhotoProps> = ({ header, currentUser, currentProfile }) => {
+  const deletePhoto = () => {
+    currentProfile!.photoURL = undefined;
+  };
+
+  const onChange = (e: any) => {
+    console.log('Uploaded file:', e ? e.target.files[0] : 'No file');
+  };
+
+  return (
+    <Grid container>
+      <Grid item xs={12} sx={{ textAlign: 'center' }}>
+        <SettingHeader header={header} />
+      </Grid>
+      <Grid item xs={12} sx={{ textAlign: 'center', marginBottom: '10px' }}>
+        <ProfilePhoto photoURL={currentProfile?.photoURL || `https://robohash.org/${currentUser!.email}.png`} />
+      </Grid>
+      <Grid item xs={12}>
+        <Typography sx={{ textAlign: 'center', color: 'rgb(0,0,0,0.4)', marginBottom: '8px' }}>
+          Be sure to use a photo that clearly shows your face
+        </Typography>
+      </Grid>
+      <Grid item xs={12} sx={{ textAlign: 'center', margin: '20px' }}>
+        <Button component="label" size="large" variant="outlined" color="secondary" onChange={onChange}>
+          Upload A Photo From Your Device
+          <input type="file" hidden />
+        </Button>
+      </Grid>
+      <Grid item xs={12} sx={{ textAlign: 'center' }}>
+        <Button disabled={!currentProfile?.photoURL} onClick={deletePhoto}>
+          <DeleteForeverIcon />
+          Delete photo
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default EditProfilePhoto;

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -6,6 +6,7 @@ import PageContainer from '../../components/PageContainer/PageContainer';
 import { makeStyles } from '@mui/styles';
 import SettingsWrapper from '../../components/SettingsWrapper/SettingsWrapper';
 import EditProfile from './EditProfile/EditProfile';
+import EditProfilePhoto from './EditProfilePhoto/EditProfilePhoto';
 import SettingHeader from '../../components/SettingsHeader/SettingsHeader';
 
 const settingsMenu = [
@@ -17,7 +18,7 @@ const settingsMenu = [
   {
     name: 'Profile photo',
     to: '/profile/settings/profile-photo',
-    component: <SettingHeader header="Profile Photo" />,
+    component: <EditProfilePhoto header="Profile Photo" />,
   },
   {
     name: 'Availability',


### PR DESCRIPTION
### What this PR does (required):
 - Adds the EditProfilePhoto page and the UI required, modeled after the ```setup-profile-photo.png``` mock.
 - Also adds a generic ProfilePhoto component that can be reused.

### Screenshots / Videos (front-end only):
<img width="780" alt="Screen Shot 2022-01-14 at 6 35 23 PM" src="https://user-images.githubusercontent.com/28790382/149598401-03f1995d-f046-4e90-b860-f0f26927f025.png">

### Any information needed to test this feature (required):
Sign up, click the avatar icon in the top right, click settings, then click Profile Photo on the left sidebar.

