### PR TITLE
Adds login for demo to Login and Signup pages

### DIFF
--- a/client/src/helpers/APICalls/loginDemoUser.ts
+++ b/client/src/helpers/APICalls/loginDemoUser.ts
@@ -1,0 +1,18 @@
+import { AuthApiData } from '../../interface/AuthApiData';
+import { FetchOptions } from '../../interface/FetchOptions';
+
+const loginDemoUser = async (): Promise<AuthApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+    credentials: 'include',
+  };
+  return await fetch(`/auth/demo`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default loginDemoUser;

--- a/client/src/pages/Login/DemoUserLogin/DemoUserLogin.tsx
+++ b/client/src/pages/Login/DemoUserLogin/DemoUserLogin.tsx
@@ -1,0 +1,24 @@
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import useStyles from '../LoginForm/useStyles';
+
+export default function Login({ handleSubmit }: any): JSX.Element {
+  const classes = useStyles();
+
+  return (
+    <form onSubmit={handleSubmit} className={classes.form} noValidate>
+      <Box textAlign="center" marginTop={5}>
+        <Button
+          type="submit"
+          size="small"
+          variant="contained"
+          color="primary"
+          className={classes.submit}
+          disableElevation
+        >
+          Login as Demo User
+        </Button>
+      </Box>
+    </form>
+  );
+}

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,6 +1,8 @@
 import { FormikHelpers } from 'formik';
 import login from '../../helpers/APICalls/login';
+import loginDemoUser from '../../helpers/APICalls/loginDemoUser';
 import LoginForm from './LoginForm/LoginForm';
+import DemoUserLogin from './DemoUserLogin/DemoUserLogin';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
 import PageContainer from '../../components/PageContainer/PageContainer';
@@ -31,10 +33,25 @@ export default function Login(): JSX.Element {
     });
   };
 
+  const handleDemoLogin = () => {
+    loginDemoUser().then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateLoginContext(data.success);
+      } else {
+        // should not get here from backend but this catch is for an unknown issue
+        console.error({ data });
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  };
+
   return (
     <PageContainer>
       <AuthPageWrapper header="Log in">
         <LoginForm handleSubmit={handleSubmit} />
+        <DemoUserLogin handleSubmit={handleDemoLogin} />
         <AuthPageFooter text="Not a member?" anchorText="Sign up" anchorTo="/signup" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -1,5 +1,7 @@
 import { FormikHelpers } from 'formik';
 import register from '../../helpers/APICalls/register';
+import loginDemoUser from '../../helpers/APICalls/loginDemoUser';
+import DemoUserLogin from '../Login/DemoUserLogin/DemoUserLogin';
 import SignUpForm from './SignUpForm/SignUpForm';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
@@ -32,10 +34,25 @@ export default function Register(): JSX.Element {
     });
   };
 
+  const handleDemoLogin = () => {
+    loginDemoUser().then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateLoginContext(data.success);
+      } else {
+        // should not get here from backend but this catch is for an unknown issue
+        console.error({ data });
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  };
+
   return (
     <PageContainer>
       <AuthPageWrapper header="Sign up">
         <SignUpForm handleSubmit={handleSubmit} />
+        <DemoUserLogin handleSubmit={handleDemoLogin} />
         <AuthPageFooter text="Already a member?" anchorText="Login" anchorTo="/login" />
       </AuthPageWrapper>
     </PageContainer>


### PR DESCRIPTION
### What this PR does (required):
- creates a Login for a demo user

### Screenshots / Videos (front-end only):
- <img width="1280" alt="Screen Shot 2022-01-16 at 9 55 52 PM" src="https://user-images.githubusercontent.com/46147798/149701293-74f08d34-574f-437c-879d-eed8a5b05f67.png">
- 
### Any information needed to test this feature (required):
- Click 'Login As Demo User'

### Any issues with the current functionality (optional):
- This PR has one error: 
````
Proxy error: Could not proxy request /auth/demo from localhost:3000 to http://localhost:3001.
````
NOTE: 'auth/demo' endpoint works successfully when using Postman and all other endpoints work as expected. Please advise. 

