### PR TITLE
Availability model

### DIFF
--- a/server/models/Availability.js
+++ b/server/models/Availability.js
@@ -1,0 +1,53 @@
+const mongoose = require("mongoose");
+
+const availabilitySchema = new mongoose.Schema({
+  petSitterId: {
+    type: mongoose.Schema.Types.ObjectId,
+    require: true,
+    ref: "User",
+  },
+  schedules: {
+    type: [scheduleSchema],
+  },
+  activatedSchedule: {
+    type: mongoose.Schema.Types.ObjectId,
+    nullable: true,
+    ref: "Schedule",
+  },
+});
+
+const scheduleSchema = new mongoose.Schema({
+  dates: {
+    type: [dateSchema],
+  },
+});
+
+const dateSchema = new mongoose.Schema({
+  day: {
+    type: String,
+    enum: [
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+      "Sunday",
+    ],
+  },
+  startTime: {
+    type: Number,
+    required: true,
+  },
+  endTime: {
+    type: Number,
+    required: true,
+  },
+});
+
+Schedule = mongoose.model("Schedule", scheduleSchema);
+
+module.exports = Availability = mongoose.model(
+  "Availability",
+  availabilitySchema
+);

--- a/server/models/Availability.js
+++ b/server/models/Availability.js
@@ -45,6 +45,10 @@ const timeSlotSchema = new mongoose.Schema({
 });
 
 const scheduleSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+  },
   timeSlots: {
     type: [timeSlotSchema],
   },


### PR DESCRIPTION
### What this PR does (required):
Creates the mongoose schema and model for Availability, and also for an individual Schedule.
Addresses Issue #84 

### Any information needed to test this feature (required):
- Manual testing in the mongo shell, or wait for controllers to be built

### Any issues with the current functionality (optional):
The Availability and Schedule models are currently in the same file, as that seemed to make sense organization-wise, but I could see an argument for separating them
